### PR TITLE
feat: タスク詳細取得・編集機能の実装 (issue #20)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -138,6 +138,25 @@ components:
         - id
         - title 
 
+    TaskUpdate:
+      type: object
+      properties:
+        title:
+          type: string
+        dueDate:
+          type: string
+          format: date
+        status:
+          type: string
+          enum: [未着手, 進行中, 完了]
+        priority:
+          type: string
+          enum: [low, medium, high]
+        category:
+          type: string
+      required:
+        - title
+
     # RecurringTask:
     #   type: object
     #   properties:
@@ -275,9 +294,12 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Task'
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Task'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -337,11 +359,26 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Task'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Task'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          description: タスクが見つからない
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                    example: ["タスクが見つかりません"]
         '500':
           $ref: '#/components/responses/InternalServerError'
     put:
@@ -356,14 +393,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Task'
+              $ref: '#/components/schemas/TaskUpdate'
       responses:
         '200':
           description: 更新成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "タスクが正常に更新されました"
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          description: タスクが見つからない
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                    example: ["タスクが見つかりません"]
         '422':
           $ref: '#/components/responses/ValidationError'
         '500':

--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -24,6 +24,40 @@ module Api
         end
       end
 
+      def show
+        validate_permissions([ 'read:tasks' ]) do
+          user_id = current_user_id
+          task = Task.find_by(id: params[:id], account_id: user_id)
+
+          if task.nil?
+            render json: { errors: [ 'タスクが見つかりません' ] }, status: :not_found
+            return
+          end
+
+          render json: {
+            data: format_task_response(task)
+          }, status: :ok
+        end
+      end
+
+      def update
+        validate_permissions([ 'write:tasks' ]) do
+          user_id = current_user_id
+          task = Task.find_by(id: params[:id], account_id: user_id)
+
+          if task.nil?
+            render json: { errors: [ 'タスクが見つかりません' ] }, status: :not_found
+            return
+          end
+
+          if task.update(task_params)
+            render json: { message: 'タスクが正常に更新されました' }, status: :ok
+          else
+            render json: { errors: task.errors.full_messages }, status: :unprocessable_entity
+          end
+        end
+      end
+
       private
 
       def task_params

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :tasks, only: [ :index, :create ]
+      resources :tasks, only: [ :index, :show, :create, :update ]
     end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/backend/spec/requests/api/v1/tasks_spec.rb
+++ b/backend/spec/requests/api/v1/tasks_spec.rb
@@ -285,6 +285,323 @@ RSpec.describe 'Tasks API', type: :request do
     end
   end
 
+  describe 'GET /api/v1/tasks/:id' do
+    let!(:task) { create(:task, account_id: user_id, title: 'Test Task', status: '進行中', priority: 'high', category: '仕事') }
+
+    context '正常系' do
+      it 'returns a successful response with 200 status' do
+        get "/api/v1/tasks/#{task.id}", headers: auth_headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns the correct task data' do
+        get "/api/v1/tasks/#{task.id}", headers: auth_headers
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['data']).to include(
+          'id' => task.id,
+          'accountId' => task.account_id,
+          'title' => task.title,
+          'status' => task.status,
+          'priority' => task.priority,
+          'category' => task.category
+        )
+        expect(json_response['data']['dueDate']).to eq(task.due_date&.iso8601)
+        expect(json_response['data']['createdAt']).to eq(task.created_at.iso8601(3))
+        expect(json_response['data']['updatedAt']).to eq(task.updated_at.iso8601(3))
+      end
+
+      it 'returns correct JSON structure' do
+        get "/api/v1/tasks/#{task.id}", headers: auth_headers
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to have_key('data')
+        expect(json_response['data']).to be_a(Hash)
+        expect(json_response['data']).to have_key('id')
+        expect(json_response['data']).to have_key('title')
+      end
+    end
+
+    context '異常系' do
+      context 'タスクが存在しない場合' do
+        it 'returns 404 when task does not exist' do
+          get "/api/v1/tasks/99999", headers: auth_headers
+          expect(response).to have_http_status(:not_found)
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['errors']).to include('タスクが見つかりません')
+        end
+      end
+
+      context '他のユーザーのタスクを取得しようとした場合' do
+        let!(:other_user_task) { create(:task, account_id: 'other-user', title: 'Other User Task') }
+
+        it 'returns 404 when trying to access another users task' do
+          get "/api/v1/tasks/#{other_user_task.id}", headers: auth_headers
+          expect(response).to have_http_status(:not_found)
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['errors']).to include('タスクが見つかりません')
+        end
+      end
+
+      context '認証関連' do
+        it '認証が失敗した場合、適切なエラーを返すこと' do
+          allow_any_instance_of(ApplicationController).to receive(:authorize) do |controller|
+            controller.render json: { message: 'Invalid token' }, status: :unauthorized
+          end
+
+          get "/api/v1/tasks/#{task.id}", headers: auth_headers
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['message']).to eq('Invalid token')
+        end
+      end
+
+      context '権限関連' do
+        it '権限が不足している場合、403エラーを返すこと' do
+          allow_any_instance_of(ApplicationController).to receive(:validate_permissions) do |controller|
+            controller.render json: { message: 'Permission denied' }, status: :forbidden
+          end
+
+          get "/api/v1/tasks/#{task.id}", headers: auth_headers
+
+          expect(response).to have_http_status(:forbidden)
+          expect(JSON.parse(response.body)['message']).to eq('Permission denied')
+        end
+      end
+    end
+
+    context 'エッジケース' do
+      it 'due_dateがnilの場合でも正常に取得される' do
+        task_without_due_date = create(:task, account_id: user_id, title: 'No Due Date Task', due_date: nil)
+
+        get "/api/v1/tasks/#{task_without_due_date.id}", headers: auth_headers
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['data']['dueDate']).to be_nil
+      end
+
+      it '特殊文字を含むタイトルでも正常に取得される' do
+        special_task = create(:task, account_id: user_id, title: 'タスク (重要) - 緊急対応が必要です！')
+
+        get "/api/v1/tasks/#{special_task.id}", headers: auth_headers
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['data']['title']).to eq('タスク (重要) - 緊急対応が必要です！')
+      end
+
+      it 'statusがnilの場合でも正常に取得される' do
+        task_without_status = create(:task, account_id: user_id, title: 'No Status Task', status: nil)
+
+        get "/api/v1/tasks/#{task_without_status.id}", headers: auth_headers
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['data']['status']).to be_nil
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/tasks/:id' do
+    let!(:task) { create(:task, account_id: user_id, title: 'Original Task', status: '未着手', priority: 'medium', category: '仕事') }
+    let(:valid_update_params) do
+      {
+        task: {
+          title: 'Updated Task',
+          status: '進行中',
+          priority: 'high',
+          category: 'プライベート',
+          due_date: Date.current + 2.weeks
+        }
+      }
+    end
+
+    context '正常系' do
+      it 'returns a successful response with 200 status' do
+        put "/api/v1/tasks/#{task.id}", params: valid_update_params, headers: auth_headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the task with new values' do
+        put "/api/v1/tasks/#{task.id}", params: valid_update_params, headers: auth_headers
+
+        task.reload
+        expect(task.title).to eq('Updated Task')
+        expect(task.status).to eq('進行中')
+        expect(task.priority).to eq('high')
+        expect(task.category).to eq('プライベート')
+        expect(task.due_date).to eq(Date.current + 2.weeks)
+      end
+
+      it 'returns success message' do
+        put "/api/v1/tasks/#{task.id}", params: valid_update_params, headers: auth_headers
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to include(
+          'message' => 'タスクが正常に更新されました'
+        )
+      end
+
+      it 'updates only specified fields' do
+        partial_params = { task: { title: 'Partially Updated Task' } }
+
+        put "/api/v1/tasks/#{task.id}", params: partial_params, headers: auth_headers
+
+        task.reload
+        expect(task.title).to eq('Partially Updated Task')
+        expect(task.status).to eq('未着手') # 元のまま
+        expect(task.priority).to eq('medium') # 元のまま
+      end
+
+      it 'handles nil values correctly' do
+        nil_params = { task: { due_date: nil, status: nil } }
+
+        put "/api/v1/tasks/#{task.id}", params: nil_params, headers: auth_headers
+
+        task.reload
+        expect(task.due_date).to be_nil
+        expect(task.status).to be_nil
+      end
+    end
+
+    context '異常系' do
+      context 'タスクが存在しない場合' do
+        it 'returns 404 when task does not exist' do
+          put "/api/v1/tasks/99999", params: valid_update_params, headers: auth_headers
+          expect(response).to have_http_status(:not_found)
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['errors']).to include('タスクが見つかりません')
+        end
+      end
+
+      context '他のユーザーのタスクを更新しようとした場合' do
+        let!(:other_user_task) { create(:task, account_id: 'other-user', title: 'Other User Task') }
+
+        it 'returns 404 when trying to update another users task' do
+          put "/api/v1/tasks/#{other_user_task.id}", params: valid_update_params, headers: auth_headers
+          expect(response).to have_http_status(:not_found)
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['errors']).to include('タスクが見つかりません')
+        end
+
+        it 'does not update the other users task' do
+          original_title = other_user_task.title
+          put "/api/v1/tasks/#{other_user_task.id}", params: valid_update_params, headers: auth_headers
+
+          other_user_task.reload
+          expect(other_user_task.title).to eq(original_title)
+        end
+      end
+
+      context 'バリデーションエラー' do
+        it 'returns 422 when title is blank' do
+          invalid_params = { task: { title: '' } }
+
+          put "/api/v1/tasks/#{task.id}", params: invalid_params, headers: auth_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['errors']).to include("Title can't be blank")
+        end
+
+        it 'returns 422 when title is too long' do
+          long_title_params = { task: { title: 'a' * 256 } }
+
+          put "/api/v1/tasks/#{task.id}", params: long_title_params, headers: auth_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+
+          json_response = JSON.parse(response.body)
+          expect(json_response['errors']).to include('Title is too long (maximum is 255 characters)')
+        end
+
+        it 'does not update task when validation fails' do
+          original_title = task.title
+          invalid_params = { task: { title: '' } }
+
+          put "/api/v1/tasks/#{task.id}", params: invalid_params, headers: auth_headers
+
+          task.reload
+          expect(task.title).to eq(original_title)
+        end
+      end
+
+      context '認証関連' do
+        it '認証が失敗した場合、適切なエラーを返すこと' do
+          allow_any_instance_of(ApplicationController).to receive(:authorize) do |controller|
+            controller.render json: { message: 'Invalid token' }, status: :unauthorized
+          end
+
+          put "/api/v1/tasks/#{task.id}", params: valid_update_params, headers: auth_headers
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['message']).to eq('Invalid token')
+        end
+      end
+
+      context '権限関連' do
+        it '権限が不足している場合、403エラーを返すこと' do
+          allow_any_instance_of(ApplicationController).to receive(:validate_permissions) do |controller|
+            controller.render json: { message: 'Permission denied' }, status: :forbidden
+          end
+
+          put "/api/v1/tasks/#{task.id}", params: valid_update_params, headers: auth_headers
+
+          expect(response).to have_http_status(:forbidden)
+          expect(JSON.parse(response.body)['message']).to eq('Permission denied')
+        end
+      end
+    end
+
+    context 'エッジケース' do
+      it '最大長のタイトルで正常に更新される' do
+        max_title_params = { task: { title: 'a' * 255 } }
+
+        put "/api/v1/tasks/#{task.id}", params: max_title_params, headers: auth_headers
+        expect(response).to have_http_status(:ok)
+
+        task.reload
+        expect(task.title).to eq('a' * 255)
+      end
+
+      it '特殊文字を含むタイトルで正常に更新される' do
+        special_params = { task: { title: 'Updated タスク (重要) - 緊急対応が必要です！' } }
+
+        put "/api/v1/tasks/#{task.id}", params: special_params, headers: auth_headers
+        expect(response).to have_http_status(:ok)
+
+        task.reload
+        expect(task.title).to eq('Updated タスク (重要) - 緊急対応が必要です！')
+      end
+
+      it 'due_dateがnilでも正常に更新される' do
+        no_due_date_params = { task: { due_date: nil } }
+
+        put "/api/v1/tasks/#{task.id}", params: no_due_date_params, headers: auth_headers
+        expect(response).to have_http_status(:ok)
+
+        task.reload
+        expect(task.due_date).to be_nil
+      end
+
+      it '各ステータス値で正常に更新される' do
+        %w[未着手 進行中 完了].each do |status|
+          params = { task: { status: status } }
+
+          put "/api/v1/tasks/#{task.id}", params: params, headers: auth_headers
+          expect(response).to have_http_status(:ok)
+
+          task.reload
+          expect(task.status).to eq(status)
+        end
+      end
+    end
+  end
+
   describe '認証・認可' do
     it 'current_user_idが正しく取得されること' do
       # Request Specでは直接controller instanceにアクセスできないため、


### PR DESCRIPTION
## Summary
- タスク詳細取得API (GET /tasks/:id) の実装
- タスク編集API (PUT /tasks/:id) の実装  
- OpenAPI仕様の完全修正とセキュリティ向上

## 実装機能

### 新規APIエンドポイント
- **GET /tasks/:id** - 特定のタスク詳細取得
- **PUT /tasks/:id** - タスクの編集（タイトル、ステータス、優先度、カテゴリ、期限）

### セキュリティ機能
- Auth0認証・権限チェック実装
- ユーザー自身のタスクのみアクセス可能
- ID・accountId等の重要フィールドは更新不可

### エラーハンドリング
- 404 Not Found（存在しないタスク）
- 422 Unprocessable Entity（バリデーションエラー）
- 401 Unauthorized（認証エラー）
- 403 Forbidden（権限エラー）

## OpenAPI仕様更新

### 新規スキーマ
- `TaskUpdate` スキーマ追加（ID除外でセキュリティ向上）

### レスポンス形式統一
- 全エンドポイントで一貫したレスポンス構造
- エラーレスポンスの標準化

## Test plan
- ✅ 71テストケース実装（全て通過）
- ✅ 正常系：タスクの取得・更新
- ✅ 異常系：存在しないタスク、他ユーザーアクセス
- ✅ バリデーション：必須項目、文字数制限
- ✅ 権限：認証・認可チェック  
- ✅ エッジケース：特殊文字、nil値
- ✅ RuboCopによるコード品質チェック

## Closes
Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)